### PR TITLE
Fix Windows build

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -148,6 +148,8 @@ genrule(
     'copy $SRCDIR\\buck.bat bundle\\buck.bat',
     'mkdir "bundle\\jre"',
     'xcopy /e $(location :openjre8-windows) bundle\\jre',
+    'mkdir "bundle\\python2"',
+    'msiexec /a $(location :python2-windows) targetdir="$TMP\\bundle\\python2" /qn',
     'mkdir "bundle\\bin"',
     'copy $(location :buck-bottle-2019.01.10.01)\\bin\\buck bundle\\bin\\buck',
     '$(exe :warp-windows) -a windows-x64 -e buck.bat -i ./bundle -o $OUT',

--- a/BUCK
+++ b/BUCK
@@ -145,10 +145,11 @@ genrule(
   ],
   cmd_exe = ' & '.join([
     'cd $TMP',
-    'mkdir "bundle/bin"',
-    'cp $SRCDIR/buck.bat ./bundle/buck.bat',
-    'cp -r $(location :openjre8-windows) ./bundle/jre',
-    'cp -r $(location :buck-bottle-2019.01.10.01)/bin/buck ./bundle/bin/buck',
+    'copy $SRCDIR\\buck.bat bundle\\buck.bat',
+    'mkdir "bundle\\jre"',
+    'xcopy /e $(location :openjre8-windows) bundle\\jre',
+    'mkdir "bundle\\bin"',
+    'copy $(location :buck-bottle-2019.01.10.01)\\bin\\buck bundle\\bin\\buck',
     '$(exe :warp-windows) -a windows-x64 -e buck.bat -i ./bundle -o $OUT',
   ]),
 )

--- a/BUCK
+++ b/BUCK
@@ -78,6 +78,14 @@ http_archive(
   strip_prefix = 'jdk8u202-b08-jre',
 )
 
+http_file(
+  name = 'python2-windows',
+  urls = [
+    'https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64.msi',
+  ],
+  sha256 = 'b74a3afa1e0bf2a6fc566a7b70d15c9bfabba3756fb077797d16fffa27800c05',
+)
+
 
 http_archive(
   name = 'buck-bottle-2019.01.10.01',

--- a/BUCK
+++ b/BUCK
@@ -143,15 +143,6 @@ genrule(
   srcs = [
     'buck.bat',
   ],
-  cmd = ' && '.join([
-    'cd $TMP',
-    'mkdir -p bundle',
-    'mkdir -p bundle/bin',
-    'cp $SRCDIR/buck.bat ./bundle/buck.bat',
-    'cp -r $(location :openjre8-windows) ./bundle/jre',
-    'cp -r $(location :buck-bottle-2019.01.10.01)/bin/buck ./bundle/bin/buck',
-    '$(exe :warp-windows) -a windows-x64 -e buck.bat -i ./bundle -o $OUT',
-  ]),
   cmd_exe = ' & '.join([
     'cd $TMP',
     'mkdir "bundle/bin"',

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buck-warp
 
-Bundling [Buck](https://buckbuild.com) and [OpenJDK](https://adoptopenjdk.net/) with [Warp](https://github.com/dgiagio/warp).
+Bundling [Buck](https://buckbuild.com), [OpenJDK](https://adoptopenjdk.net/), and [Python2](https://www.python.org/) with [Warp](https://github.com/dgiagio/warp).
 
 You can download a self-contained version of Buck from the [releases page](https://github.com/njlr/buck-warp/releases).
 

--- a/buck.bat
+++ b/buck.bat
@@ -6,4 +6,6 @@ set BUCK_HOME=%~dp0
 
 set JAVA_HOME=%BUCK_HOME%jre
 
+set PATH=%BUCK_HOME%python2;%PATH%
+
 python %BUCK_HOME%bin\buck %* 


### PR DESCRIPTION
- Fix build commands for Windows
    - Now it works on `cmd`
- Add Python2
    - Now truly _standalone_ buck is here.
    - This change needs `msiexec` , so Windows builds on other platforms have been omitted.