### PR TITLE
Buck needs Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buck-warp
 
-Bundling [Buck](https://buckbuild.com), [OpenJDK](https://adoptopenjdk.net/), and [Python3](https://www.python.org/) with [Warp](https://github.com/dgiagio/warp).
+Bundling [Buck](https://buckbuild.com), [OpenJDK](https://adoptopenjdk.net/), and [Python2](https://www.python.org/) with [Warp](https://github.com/dgiagio/warp).
 
 You can download a self-contained version of Buck from the [releases page](https://github.com/wx257osn2/buck-warp/releases).
 

--- a/buck.bat
+++ b/buck.bat
@@ -6,4 +6,6 @@ set BUCK_HOME=%~dp0
 
 set JAVA_HOME=%BUCK_HOME%jre
 
-%BUCK_HOME%python2\python.exe %BUCK_HOME%bin\buck %*
+set PATH=%BUCK_HOME%python2;%PATH%
+
+python %BUCK_HOME%bin\buck %*

--- a/buck.bat
+++ b/buck.bat
@@ -6,4 +6,4 @@ set BUCK_HOME=%~dp0
 
 set JAVA_HOME=%BUCK_HOME%jre
 
-%BUCK_HOME%python3\python.exe %BUCK_HOME%bin\buck %*
+%BUCK_HOME%python2\python.exe %BUCK_HOME%bin\buck %*

--- a/buck.sh
+++ b/buck.sh
@@ -4,4 +4,6 @@ BUCK_HOME=$(dirname "$(realpath $0)")
 
 export JAVA_HOME="$BUCK_HOME/jre";
 
-"$BUCK_HOME/python2/bin/python2" "$BUCK_HOME/bin/buck" "$@"
+export PATH=$BUCK_HOME/python2/bin:${PATH}
+
+python2 "$BUCK_HOME/bin/buck" "$@"

--- a/buck.sh
+++ b/buck.sh
@@ -4,4 +4,4 @@ BUCK_HOME=$(dirname "$(realpath $0)")
 
 export JAVA_HOME="$BUCK_HOME/jre";
 
-"$BUCK_HOME/python3/bin/python3" "$BUCK_HOME/bin/buck" "$@"
+"$BUCK_HOME/python2/bin/python2" "$BUCK_HOME/bin/buck" "$@"

--- a/python38._pth
+++ b/python38._pth
@@ -1,5 +1,0 @@
-python38.zip
-.
-
-# Uncomment to run site.main() automatically
-import site


### PR DESCRIPTION
At least buck-2020.06.29.01 can't work correctly on Python3, so this PR reverts the commit that updates Python major version from 2 to 3.  
Also buck needs Python (`python` or `python2`) on `PATH` , so this PR fixed the scripts to set Python path to `PATH` .